### PR TITLE
Archive files recursively

### DIFF
--- a/main.go
+++ b/main.go
@@ -670,6 +670,10 @@ func makeArchive(dir string) error {
   	}
 		return nil
 	})
+
+  if err != nil {
+	  return err
+	}
   
   log.Info("The body is in the casket!", "casket", dir + ".tar.gz")
   return nil


### PR DESCRIPTION
Fixes #9 by using [filepath.WalkDir](https://pkg.go.dev/path/filepath#WalkDir) to recursively archive files.